### PR TITLE
JS block template fix

### DIFF
--- a/nplbam/app/templates/base_template.html
+++ b/nplbam/app/templates/base_template.html
@@ -5,7 +5,7 @@
         <title>NPLB - {{ title }}</title>
         <link rel="stylesheet" href="static/css/normalize.css" />
         <link rel="stylesheet" href="static/css/{% block css %}{% endblock %}.css" />
-        <script type="text/javascript" src="static/js/{% block js %}{% endblock %}.js"></script>
+        {% block js %}<script type="text/javascript" src="static/js/.js"></script>{% endblock %}
     </head>
     <body>
         <header>

--- a/nplbam/app/templates/base_template.html
+++ b/nplbam/app/templates/base_template.html
@@ -5,7 +5,7 @@
         <title>NPLB - {{ title }}</title>
         <link rel="stylesheet" href="static/css/normalize.css" />
         <link rel="stylesheet" href="static/css/{% block css %}{% endblock %}.css" />
-        {% block js %}<script type="text/javascript" src="static/js/.js"></script>{% endblock %}
+        {% block js %}{% endblock %}
     </head>
     <body>
         <header>

--- a/nplbam/app/templates/gallery.html
+++ b/nplbam/app/templates/gallery.html
@@ -3,7 +3,7 @@
 {# Add the css name to the file. #}
 {% block css %}gallery{% endblock %}
 {# Add the javascript name to the file. #}
-{% block js %}gallery{% endblock %}
+{% block js %}<script type="text/javascript" src="static/js/gallery.js"></script>{% endblock %}
 {# Add the main method #}
 {% block main %}
 <div>


### PR DESCRIPTION
Fixed the JS block since not every page has a js block. For pages that did not it would look like

<script type="text/javascript" src="static/js/.js"></script>

This is probably a problem so it is now fixed.